### PR TITLE
fix: add fullscreen TapHandler for wallpaper and dashboard popup click-to-dismiss

### DIFF
--- a/src/popups/Dashboard.qml
+++ b/src/popups/Dashboard.qml
@@ -54,24 +54,14 @@ PanelWindow {
     anchors.top:   true
     anchors.left:  true
     anchors.right: true
+    anchors.bottom: true
 
     implicitHeight: Theme.notchHeight + Theme.dashboardHeight
     exclusionMode:  ExclusionMode.Ignore
 
     WlrLayershell.layer:         WlrLayer.Overlay
-    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
-
-    // ── Mask — input/paint region limited to sizer only ──────────────────────
-    mask: Region { item: maskProxy }
-    Item {
-        id:     maskProxy
-        x:      ((root.width - sizer.width) / 2) + root.fw
-        // topMargin matches sizer exactly — no fh offset
-        y:      Theme.notchHeight
-        width:  sizer.width -root.fw
-        height: sizer.height-Theme.notchHeight
-    }
-
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+    
     // ── Window visibility gate ────────────────────────────────────────────────
     property bool windowVisible: false
 
@@ -183,6 +173,13 @@ PanelWindow {
         onTriggered: {
             root.windowVisible = false
             tabBar.reset()
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        TapHandler {
+            onTapped: Popups.dashboardOpen = false // or wallpaperOpen = false
         }
     }
 

--- a/src/popups/WallpaperPopup.qml
+++ b/src/popups/WallpaperPopup.qml
@@ -12,9 +12,10 @@ import "../"
 PanelWindow {
     id: root
 
+    anchors.top:    true
     anchors.left:   true
     anchors.right:  true
-    anchors.bottom: true
+    anchors.bottom: true 
 
     implicitHeight: root.panelHeight + Theme.borderWidth
 
@@ -22,21 +23,12 @@ PanelWindow {
     color:         "transparent"
 
     WlrLayershell.layer:         WlrLayer.Overlay
-    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
 
     readonly property int panelWidth:  980
     readonly property int panelHeight: 420
     readonly property int fw:          Theme.notchRadius
     readonly property int fh:          Theme.notchRadius
-
-    mask: Region { item: maskProxy }
-    Item {
-        id: maskProxy
-        x:      (root.width - sizer.width) / 2
-        y:      root.height - sizer.height - Theme.borderWidth
-        width:  sizer.width
-        height: sizer.height
-    }
 
     property bool windowVisible: false
     visible: windowVisible
@@ -109,6 +101,13 @@ PanelWindow {
             } else {
                 closeTimer.restart()
             }
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        TapHandler {
+            onTapped: Popups.wallpaperOpen = false // or wallpaperOpen = false
         }
     }
 


### PR DESCRIPTION
Fixes a issue where click anywhere to close popup stopped working due to exclusive keyboard focus.

Now keyboard focus is OnDemand and Full screen tap handler behind UI Layer to register out of popup clicks