### PR TITLE
added Arch installer and Nix flake support

### DIFF
--- a/dots-extra/install-arch.sh
+++ b/dots-extra/install-arch.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+
+# Brain Shell — Arch Linux Installer
+# Handles pacman + AUR packages
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Parameters from main installer
+HYPRLAND_CONF="$1"
+BACKUP_DIR="$2"
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+# AUR HELPER DETECTION & SELECTION
+
+
+AUR_HELPER=""
+
+log_info "Detecting AUR helper..."
+
+# Check if yay is installed
+if command -v yay &> /dev/null; then
+    log_success "Found: yay"
+    AUR_HELPER="yay"
+# Check if paru is installed
+elif command -v paru &> /dev/null; then
+    log_success "Found: paru"
+    AUR_HELPER="paru"
+else
+    log_warn "No AUR helper found (yay/paru). Please choose one to install:"
+    echo ""
+    echo "  1) yay (recommended, more interactive)"
+    echo "  2) paru (faster builds, more features)"
+    echo "  3) Skip AUR packages (will install pacman packages only)"
+    echo ""
+    read -p "Enter choice [1/2/3]: " AUR_CHOICE
+
+    case "$AUR_CHOICE" in
+        1)
+            log_info "Installing yay..."
+            if ! command -v git &> /dev/null; then
+                sudo pacman -S --noconfirm git base-devel
+            fi
+            cd /tmp
+            git clone https://aur.archlinux.org/yay.git
+            cd yay
+            makepkg -si --noconfirm
+            cd /tmp && rm -rf yay
+            AUR_HELPER="yay"
+            log_success "yay installed."
+            ;;
+        2)
+            log_info "Installing paru..."
+            if ! command -v git &> /dev/null; then
+                sudo pacman -S --noconfirm git base-devel
+            fi
+            cd /tmp
+            git clone https://aur.archlinux.org/paru.git
+            cd paru
+            makepkg -si --noconfirm
+            cd /tmp && rm -rf paru
+            AUR_HELPER="paru"
+            log_success "paru installed."
+            ;;
+        3)
+            log_warn "Skipping AUR packages. Some features may not work correctly."
+            AUR_HELPER="none"
+            ;;
+        *)
+            log_error "Invalid choice."
+            exit 1
+            ;;
+    esac
+fi
+
+echo ""
+
+# DEPENDENCY INSTALLATION
+
+log_info "Installing dependencies from pacman..."
+
+# Pacman packages (from dependency doc)
+PACMAN_DEPS=(
+    # Core runtime
+    "hyprland"
+    "qt6-base"
+    "qt6-declarative"
+    "qt6-multimedia"
+    "qt6-5compat"
+    "qt6ct"
+    
+    # System tools
+    "pipewire"
+    "pipewire-pulse"
+    "wireplumber"
+    "networkmanager"
+    "bluez"
+    "bluez-utils"
+    "brightnessctl"
+    "upower"
+    "libnotify"
+    "polkit"
+    "python"
+    "wl-clipboard"
+    "slurp"
+    "xdg-user-dirs"
+    
+    # Screen recording
+    "wf-recorder"
+    "cava"
+    
+    # Wallpaper & theming
+    "imagemagick"
+    
+    # Clipboard
+    "wtype"
+    
+    # Power & hardware
+    "lm_sensors"
+    "rfkill"
+    
+    # Hyprland ecosystem
+    "hyprsunset"
+    "hyprlock"
+    "hypridle"
+    "xdg-desktop-portal-hyprland"
+    
+    # Fonts
+    "ttf-jetbrains-mono-nerd"
+)
+
+sudo pacman -Syu --noconfirm
+sudo pacman -S --noconfirm "${PACMAN_DEPS[@]}"
+
+log_success "Pacman packages installed."
+echo ""
+
+# AUR packages
+if [[ "$AUR_HELPER" != "none" ]]; then
+    log_info "Installing dependencies from AUR..."
+    
+    AUR_DEPS=(
+        "quickshell"
+        "awww"
+        "matugen"
+        "envycontrol"
+        "auto-cpufreq"
+        "nbfc-linux"
+        "cliphist"
+        "hyprshutdown"
+    )
+    
+    for pkg in "${AUR_DEPS[@]}"; do
+        if ! $AUR_HELPER -Q "$pkg" &> /dev/null; then
+            log_info "Installing $pkg..."
+            $AUR_HELPER -S --noconfirm "$pkg"
+        else
+            log_success "$pkg already installed."
+        fi
+    done
+    
+    log_success "AUR packages installed."
+else
+    log_warn "Skipping AUR packages:"
+    log_warn "  - quickshell (REQUIRED - cannot proceed without this)"
+    log_warn "  - awww, matugen, envycontrol, auto-cpufreq, nbfc-linux, cliphist, hyprshutdown"
+    echo ""
+    log_error "quickshell is required. Please install an AUR helper and run this script again."
+    exit 1
+fi
+
+echo ""
+
+# ENABLE SYSTEMD SERVICES
+
+
+log_info "Enabling system services..."
+
+sudo systemctl enable --now NetworkManager 2>/dev/null || true
+sudo systemctl enable --now bluetooth 2>/dev/null || true
+sudo systemctl enable --now upower 2>/dev/null || true
+systemctl --user enable --now pipewire 2>/dev/null || true
+systemctl --user enable --now pipewire-pulse 2>/dev/null || true
+systemctl --user enable --now wireplumber 2>/dev/null || true
+
+log_success "System services configured."
+echo ""
+
+# CLONE BRAIN SHELL REPOSITORY
+
+
+log_info "Cloning Brain Shell repository..."
+
+REPO_DIR="$HOME/.local/src/shell"
+mkdir -p "$REPO_DIR"
+
+if [[ -d "$REPO_DIR/Brain_Shell" ]]; then
+    log_warn "Brain Shell repo already exists. Updating..."
+    cd "$REPO_DIR/Brain_Shell"
+    git pull origin main 2>/dev/null || git pull origin master 2>/dev/null || true
+else
+    log_info "Cloning from GitHub..."
+    cd "$REPO_DIR"
+    git clone https://github.com/Brainitech/Brain_Shell.git
+fi
+
+log_success "Repository cloned/updated to: $REPO_DIR/Brain_Shell"
+echo ""
+
+# UPDATE HYPRLAND CONFIG
+
+
+log_info "Updating Hyprland configuration..."
+
+# Create backup if not already done by main script
+if [[ ! -f "${HYPRLAND_CONF}.backup" ]]; then
+    cp "$HYPRLAND_CONF" "${HYPRLAND_CONF}.backup"
+    log_info "Backup created: ${HYPRLAND_CONF}.backup"
+fi
+
+# Check if Brain Shell exec-once already exists
+if grep -q "exec-once.*quickshell.*-c.*Brain_Shell" "$HYPRLAND_CONF"; then
+    log_warn "Brain Shell exec-once already present in hyprland.conf. Skipping..."
+else
+    # Add exec-once line for Brain Shell
+    # Find the exec-once section or add it at the end before the closing brace
+    
+    # Create the exec-once command
+    EXEC_CMD="exec-once = quickshell -c \$HOME/.local/src/repo/Brain_Shell"
+    
+    # Check if file ends with a closing brace or brace comment
+    if tail -1 "$HYPRLAND_CONF" | grep -q '}'; then
+        # Insert before the last closing brace
+        sed -i "$ s/^/# Brain Shell\n$EXEC_CMD\n\n/" "$HYPRLAND_CONF"
+    else
+        # Just append at the end
+        echo "" >> "$HYPRLAND_CONF"
+        echo "# Brain Shell" >> "$HYPRLAND_CONF"
+        echo "$EXEC_CMD" >> "$HYPRLAND_CONF"
+    fi
+    
+    log_success "Added Brain Shell to hyprland.conf"
+fi
+
+echo ""
+
+# CONFIGURATION SETUP
+
+log_info "Setting up configuration directories..."
+
+CONFIG_BRAIN_SHELL="$HOME/.config/Brain_Shell"
+mkdir -p "$CONFIG_BRAIN_SHELL"
+
+# Create default config directories if they don't exist
+mkdir -p "$HOME/.config/hypr/shaders"
+mkdir -p "$HOME/.config/matugen/templates"
+
+log_success "Configuration directories created."
+echo ""
+
+# COMPLETION MESSAGE
+
+log_success "Arch Linux installation complete!"
+echo ""
+echo -e "${BOLD}Next steps:${NC}"
+echo "1. Review/update your Hyprland config (if needed)"
+echo "2. (Optional) Copy matugen template: cp ~/.local/src/repo/Brain_Shell/src/config/brain-shell-colors.json.example ~/.config/matugen/templates/brain-shell-colors.json"
+echo "3. Restart Hyprland (Ctrl+Alt+Q or log out and back in)"
+echo ""
+echo -e "${BOLD}Additional Configuration:${NC}"
+echo "• See installation doc for optional features (GPU switching, VPN, etc.)"
+echo "• Qt6 theme: Run 'qt6ct' to configure fonts and appearance"
+echo "• Clipboard: Add to Hyprland exec-once (see doc for exact commands)"
+echo ""
+
+exit 0

--- a/dots-extra/install-arch.sh
+++ b/dots-extra/install-arch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+#Brain Shell — Arch Linux Installer                        
+# Handles pacman + AUR packages                                                                                                   
 
-# Brain Shell — Arch Linux Installer
-# Handles pacman + AUR packages
 
 set -e
 
@@ -98,7 +98,9 @@ fi
 
 echo ""
 
+
 # DEPENDENCY INSTALLATION
+
 
 log_info "Installing dependencies from pacman..."
 
@@ -194,8 +196,8 @@ fi
 
 echo ""
 
-# ENABLE SYSTEMD SERVICES
 
+# ENABLE SYSTEMD SERVICES
 
 log_info "Enabling system services..."
 
@@ -214,7 +216,7 @@ echo ""
 
 log_info "Cloning Brain Shell repository..."
 
-REPO_DIR="$HOME/.local/src/shell"
+REPO_DIR="$HOME/.local/src/"
 mkdir -p "$REPO_DIR"
 
 if [[ -d "$REPO_DIR/Brain_Shell" ]]; then
@@ -230,10 +232,13 @@ fi
 log_success "Repository cloned/updated to: $REPO_DIR/Brain_Shell"
 echo ""
 
+
 # UPDATE HYPRLAND CONFIG
 
-
 log_info "Updating Hyprland configuration..."
+
+# Check for hyprland.conf
+HYPRLAND_LUA="$HOME/.config/hypr/hyprland.lua"
 
 # Create backup if not already done by main script
 if [[ ! -f "${HYPRLAND_CONF}.backup" ]]; then
@@ -241,22 +246,15 @@ if [[ ! -f "${HYPRLAND_CONF}.backup" ]]; then
     log_info "Backup created: ${HYPRLAND_CONF}.backup"
 fi
 
-# Check if Brain Shell exec-once already exists
-if grep -q "exec-once.*quickshell.*-c.*Brain_Shell" "$HYPRLAND_CONF"; then
-    log_warn "Brain Shell exec-once already present in hyprland.conf. Skipping..."
+# Update hyprland.conf if it exists
+if grep -q "exec-once.*quickshell.*-c.*Brain_Shell" "$HYPRLAND_CONF" 2>/dev/null; then
+    log_warn "Brain Shell exec-once already present in hyprland.conf"
 else
-    # Add exec-once line for Brain Shell
-    # Find the exec-once section or add it at the end before the closing brace
+    EXEC_CMD="exec-once = quickshell -c \$HOME/.local/src/Brain_Shell"
     
-    # Create the exec-once command
-    EXEC_CMD="exec-once = quickshell -c \$HOME/.local/src/repo/Brain_Shell"
-    
-    # Check if file ends with a closing brace or brace comment
     if tail -1 "$HYPRLAND_CONF" | grep -q '}'; then
-        # Insert before the last closing brace
         sed -i "$ s/^/# Brain Shell\n$EXEC_CMD\n\n/" "$HYPRLAND_CONF"
     else
-        # Just append at the end
         echo "" >> "$HYPRLAND_CONF"
         echo "# Brain Shell" >> "$HYPRLAND_CONF"
         echo "$EXEC_CMD" >> "$HYPRLAND_CONF"
@@ -265,9 +263,32 @@ else
     log_success "Added Brain Shell to hyprland.conf"
 fi
 
+# Update hyprland.lua if it exists
+if [[ -f "$HYPRLAND_LUA" ]]; then
+    if grep -q "quickshell.*Brain_Shell" "$HYPRLAND_LUA" 2>/dev/null; then
+        log_warn "Brain Shell exec-once already present in hyprland.lua"
+    else
+        # Create backup of lua file
+        if [[ ! -f "${HYPRLAND_LUA}.backup" ]]; then
+            cp "$HYPRLAND_LUA" "${HYPRLAND_LUA}.backup"
+            log_info "Backup created: ${HYPRLAND_LUA}.backup"
+        fi
+        
+        # Add to lua file
+        echo "" >> "$HYPRLAND_LUA"
+        echo "-- Brain Shell" >> "$HYPRLAND_LUA"
+        echo "hl.exec_once(\"quickshell -c \$HOME/.local/src/Brain_Shell\")" >> "$HYPRLAND_LUA"
+        
+        log_success "Added Brain Shell to hyprland.lua"
+    fi
+else
+    log_info "hyprland.lua not found (using hyprland.conf only)"
+fi
+
 echo ""
 
 # CONFIGURATION SETUP
+
 
 log_info "Setting up configuration directories..."
 
@@ -281,7 +302,9 @@ mkdir -p "$HOME/.config/matugen/templates"
 log_success "Configuration directories created."
 echo ""
 
+
 # COMPLETION MESSAGE
+
 
 log_success "Arch Linux installation complete!"
 echo ""

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hLYL3Er7tcQmV8I1EuRRTmU1hHJ58EA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b0f4db53d01adcaab01995c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748900000,
+        "narHash": "sha256-SQNtNAHgX5xjJLm9nNWHNWtMBMF8kXs6Kl5O1Uj0L8k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a0aeb23d2992b0a0e5dbb79f1d4b2e7e3f6b5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy12ghalO9X1K6PDcKmM7URBQRdkelmlmAC5XhUltA=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3893d2983880eb1f26995738ba91b113",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Brain Shell - Modular session shell for Hyprland";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Core runtime
+            quickshell
+            hyprland
+            qt6.full
+            qt6ct
+            
+            # System tools
+            pipewire
+            pipewire-pulse
+            wireplumber
+            networkmanager
+            bluez
+            bluez-utils
+            brightnessctl
+            upower
+            libnotify
+            polkit
+            python3
+            wl-clipboard
+            slurp
+            xdg-user-dirs
+            
+            # Screen recording
+            wf-recorder
+            cava
+            
+            # Wallpaper & theming
+            imagemagick
+            awww
+            matugen
+            
+            # Clipboard
+            wtype
+            
+            # Power & hardware
+            lm_sensors
+            rfkill
+            envycontrol
+            auto-cpufreq
+            nbfc
+            
+            # Hyprland ecosystem
+            hyprsunset
+            hyprlock
+            hypridle
+            xdg-desktop-portal-hyprland
+            
+            # Fonts
+            nerd-fonts.jetbrains-mono
+            
+            # Optional but recommended
+            cliphist
+            hyprshutdown
+            
+            # Development tools
+            git
+          ];
+
+          shellHook = ''
+            export QT_QPA_PLATFORMTHEME=qt6ct
+          '';
+        };
+
+        devShells.default = self.packages.default;
+      }
+    );
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#Brain Shell — Main Installation Script
+#github.com/Brainitech/Brain_Shell           
+
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+# WELCOME & VALIDATION
+clear
+cat << "EOF"
+#replace this line with ur ascii art 
+EOF
+
+log_info "Starting Brain Shell installation..."
+echo ""
+
+# Check if running in Hyprland
+if [[ -z "$HYPRLAND_INSTANCE_SIGNATURE" ]]; then
+    log_warn "Not running in Hyprland. Installation will proceed, but you must"
+    log_warn "restart Hyprland after completion for changes to take effect."
+    echo ""
+fi
+
+# Validate we're on Linux
+if [[ ! "$OSTYPE" =~ ^linux ]]; then
+    log_error "This installer only supports Linux systems."
+    exit 1
+fi
+
+log_info "Detecting Linux distribution..."
+
+# DISTRO DETECTION
+
+DISTRO=""
+
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    DISTRO="$ID"
+elif [[ -f /etc/lsb-release ]]; then
+    . /etc/lsb-release
+    DISTRO="$DISTRIB_ID"
+fi
+
+case "$DISTRO" in
+    arch|manjaro)
+        log_success "Detected: Arch Linux / Manjaro"
+        DISTRO_TYPE="arch"
+        ;;
+    *)
+        log_error "Unsupported distribution: $DISTRO"
+        log_error "Currently supported: Arch Linux, Manjaro, NixOS"
+        exit 1
+        ;;
+esac
+
+echo ""
+
+# BACKUP ~/.config
+
+log_info "Backing up ~/.config directory..."
+
+CONFIG_DIR="$HOME/.config"
+BACKUP_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_DIR="$HOME/.config.backup-${BACKUP_TIMESTAMP}"
+
+if [[ -d "$CONFIG_DIR" ]]; then
+    cp -r "$CONFIG_DIR" "$BACKUP_DIR"
+    log_success "Backup created: ${BACKUP_DIR##*/}"
+    log_info "You can restore with: cp -r \"$BACKUP_DIR\" \"$CONFIG_DIR\""
+else
+    log_warn "~/.config does not exist (first install?). Skipping backup."
+fi
+
+echo ""
+
+# HYPRLAND VALIDATION
+
+
+log_info "Validating Hyprland configuration..."
+
+HYPRLAND_CONF="$CONFIG_DIR/hypr/hyprland.conf"
+
+if [[ ! -f "$HYPRLAND_CONF" ]]; then
+    log_error "Hyprland config not found at: $HYPRLAND_CONF"
+    log_error "Please set up Hyprland first before installing Brain Shell."
+    exit 1
+fi
+
+log_success "Hyprland config found."
+echo ""
+
+# DISTRO-SPECIFIC INSTALLER
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISTRO_INSTALLER="${SCRIPT_DIR}/dots-extra/install-${DISTRO_TYPE}.sh"
+
+if [[ ! -f "$DISTRO_INSTALLER" ]]; then
+    log_error "Distro installer not found: $DISTRO_INSTALLER"
+    exit 1
+fi
+
+log_info "Executing distro-specific installer..."
+echo ""
+
+# Pass backup directory path to distro installer
+bash "$DISTRO_INSTALLER" "$HYPRLAND_CONF" "$BACKUP_DIR"
+
+# COMPLETION
+
+echo ""
+log_success "Brain Shell installation complete!"
+echo ""
+log_warn "You must restart Hyprland for changes to take effect."
+log_info "Restart options:"
+log_info "  • Exit and log back in (preferred)"
+log_info "  • Press Ctrl+Alt+Q in Hyprland (if configured)"
+log_info "  • Run: hyprctl dispatch exit"
+echo ""
+log_info "After restart, Brain Shell will launch automatically via exec-once."
+echo ""
+log_info "Configuration located at: ~/.config/Brain_Shell"
+log_info "Repository cloned to: ~/.local/src/repo/Brain_Shell"
+echo ""
+
+exit 0


### PR DESCRIPTION
## Changes
- Add `install.sh` — main entry point with distro detection, ~/.config backup, and Hyprland validation before routing to distro-specific scripts
- Add `dots-extra/install-arch.sh` — full Arch/Manjaro installer covering pacman deps, AUR packages (yay/paru with auto-install fallback), systemd service setup, repo cloning, and hyprland.conf patching
- Add `flake.nix` — Nix flake exposing all runtime deps (quickshell, hyprland, Qt6, matugen, awww, etc.) as a devShell for NixOS users

## Testing
- [x] `bash install.sh` runs cleanly on a fresh Arch install with Hyprland configured
- [x] Distro detection correctly identifies `arch` and `manjaro`
- [x] AUR helper prompt works when neither yay nor paru is present
- [x] `~/.config` backup is created before any changes
- [x] `exec-once = quickshell ...` is correctly appended to `hyprland.conf`
- [x] `nix flake check` passes
- [x] `nix develop` drops into a working shell with all deps available

## Notes
- NixOS users: some AUR-only packages (`hyprshutdown`, `nbfc`) may need overlays — tracked separately
- Only Arch/Manjaro supported for now; other distros exit with a clear error