### PR TITLE
Feat/Fix: Smart Keybind Conflict Handling & UI Enhancements

### DIFF
--- a/dots-extra/install-arch.sh
+++ b/dots-extra/install-arch.sh
@@ -284,6 +284,26 @@ fi
 
 echo ""
 
+# CONFIGURATION SETUP
+log_info "Setting up Brain Shell configuration..."
+
+CONFIG_BRAIN_SHELL="$HOME/.config/Brain_Shell"
+USER_DATA_DIR="$CONFIG_BRAIN_SHELL/src/user_data"
+
+mkdir -p "$CONFIG_BRAIN_SHELL"
+mkdir -p "$HOME/.config/hypr/shaders"
+mkdir -p "$HOME/.config/matugen/templates"
+mkdir -p "$USER_DATA_DIR"
+mkdir -p "$HOME/.config/hypr"
+
+cp -n "$HOME/.local/src/Brain_Shell/src/config/hypridle.conf" "$HOME/.config/hypr/"
+
+echo "{\"configProvider\": \"$CONFIG_TYPE\"}" > "$USER_DATA_DIR/config_Provider.json"
+echo "{}" > "$USER_DATA_DIR/keybinds.json"
+
+log_success "Configuration directories created and config_Provider.json set."
+
+
 # ==============================================================================
 # KEYBIND CONFLICT DETECTION
 # ==============================================================================
@@ -366,24 +386,6 @@ if conflicts_found:
 else:
     print("\033[0;32m[✓]\033[0m No keybind conflicts detected.")
 EOF
-
-# CONFIGURATION SETUP
-log_info "Setting up Brain Shell configuration..."
-
-CONFIG_BRAIN_SHELL="$HOME/.config/Brain_Shell"
-USER_DATA_DIR="$CONFIG_BRAIN_SHELL/src/user_data"
-
-mkdir -p "$CONFIG_BRAIN_SHELL"
-mkdir -p "$HOME/.config/hypr/shaders"
-mkdir -p "$HOME/.config/matugen/templates"
-mkdir -p "$USER_DATA_DIR"
-mkdir -p "$HOME/.config/hypr"
-
-cp -n "$HOME/.local/src/Brain_Shell/src/config/hypridle.conf" "$HOME/.config/hypr/"
-
-echo "{\"configProvider\": \"$CONFIG_TYPE\"}" > "$USER_DATA_DIR/config_Provider.json"
-
-log_success "Configuration directories created and config_Provider.json set."
 
 # COMPLETION MESSAGE
 

--- a/dots-extra/install-arch.sh
+++ b/dots-extra/install-arch.sh
@@ -284,6 +284,88 @@ fi
 
 echo ""
 
+# ==============================================================================
+# KEYBIND CONFLICT DETECTION
+# ==============================================================================
+log_info "Checking for Hyprland keybind conflicts..."
+
+python3 << 'EOF'
+import subprocess, json, os
+
+# Brain Shell's exact defaults
+defaults = {
+    "dashboard-home": {"mods": "SUPER", "key": "D", "label": "Dashboard: System"},
+    "dashboard-stats": {"mods": "CTRL + SHIFT", "key": "ESCAPE", "label": "Dashboard: Home"},
+    "dashboard-kanban": {"mods": "SUPER", "key": "Z", "label": "Dashboard: Tasks"},
+    "dashboard-launcher": {"mods": "SUPER", "key": "Q", "label": "Dashboard: Apps"},
+    "dashboard-config": {"mods": "SUPER", "key": "C", "label": "Dashboard: Config"},
+    "PowerMenu-toggle": {"mods": "SUPER", "key": "ESCAPE", "label": "Arch Menu"},
+    "notification-toggle": {"mods": "SUPER", "key": "N", "label": "Notifications"},
+    "wallpaper-toggle": {"mods": "SUPER", "key": "W", "label": "Wallpaper"},
+    "clipboard-toggle": {"mods": "SUPER", "key": "V", "label": "Clipboard"},
+    "wifi-toggle": {"mods": "SUPER + ALT", "key": "W", "label": "Network: Wi-Fi"},
+    "bluetooth-toggle": {"mods": "SUPER + ALT", "key": "B", "label": "Network: Bluetooth"},
+    "vpn-toggle": {"mods": "SUPER + ALT", "key": "G", "label": "Network: VPN"},
+    "hotspot-toggle": {"mods": "SUPER + ALT", "key": "H", "label": "Network: Hotspot"},
+    "audioOut-toggle": {"mods": "SUPER", "key": "A", "label": "Audio: Output"},
+    "audioIn-toggle": {"mods": "SUPER + ALT", "key": "I", "label": "Audio: Input"},
+    "audioMix-toggle": {"mods": "SUPER", "key": "M", "label": "Audio: Mixer"},
+    "focus-toggle": {"mods": "SUPER", "key": "B", "label": "Focus Mode"},
+    "screenrec-on": {"mods": "ALT", "key": "F9", "label": "Screen Record"}
+}
+
+def mods_to_mask(mods_str):
+    mask = 0
+    parts = [p.strip().upper() for p in mods_str.split('+')]
+    if "SUPER" in parts: mask |= 64
+    if "SHIFT" in parts: mask |= 1
+    if "CTRL" in parts: mask |= 4
+    if "ALT" in parts: mask |= 8
+    return mask
+
+try:
+    hypr_binds_json = subprocess.check_output(["hyprctl", "binds", "-j"], stderr=subprocess.DEVNULL).decode('utf-8')
+    hypr_binds = json.loads(hypr_binds_json)
+except Exception:
+    print("\033[1;33m[WARN]\033[0m Could not connect to Hyprland. Skipping conflict check.")
+    exit(0)
+
+conflicts_found = False
+unbound_config = {}
+
+for action, data in defaults.items():
+    mask = mods_to_mask(data["mods"])
+    key = data["key"].lower()
+    
+    for hb in hypr_binds:
+        if hb.get("submap", "") != "": continue
+        if hb.get("mouse"): continue
+        
+        # Match modifier mask and exact key
+        if hb.get("modmask") == mask and str(hb.get("key", "")).lower() == key:
+            if not conflicts_found:
+                print("\n\033[0;31m[!] KEYBIND CONFLICTS DETECTED\033[0m")
+                print("The following Brain Shell defaults conflict with your active Hyprland configuration:")
+                conflicts_found = True
+            
+            desc = hb.get("dispatcher", "") + (" " + hb.get("arg", "") if hb.get("arg") else "")
+            print(f"  - {data['mods']} + {data['key']} ({data['label']}) -> Used by: {desc}")
+            
+            # Queue this bind to be explicitly wiped
+            unbound_config[action] = {"mods": "", "key": ""}
+            break
+
+if conflicts_found:
+    config_path = os.path.expanduser("~/.config/Brain_Shell/src/user_data/keybinds.json")
+    
+    with open(config_path, 'w') as f:
+        json.dump(unbound_config, f, indent=2)
+        
+    print("\n\033[1;33m[ACTION TAKEN]\033[0m These conflicting binds have been left unbound in Brain Shell.")
+    print("You can manually assign them a new key combination in the Dashboard > Config tab later.\n")
+else:
+    print("\033[0;32m[✓]\033[0m No keybind conflicts detected.")
+EOF
 
 # CONFIGURATION SETUP
 log_info "Setting up Brain Shell configuration..."

--- a/src/services/config_tab/KeybindService.qml
+++ b/src/services/config_tab/KeybindService.qml
@@ -248,6 +248,18 @@ QtObject {
         saveAndReload()
     }
 
+	// Allows the UI to explicitly unbind an action (or preserve installer unbinds)
+    function unbindBinding(action) {
+        var old = root.keybinds[action]
+        if (!old) return
+        
+        var copy = Object.assign({}, root.keybinds)
+        copy[action] = { mods: "", key: "", label: old.label, group: old.group }
+        root.keybinds = copy
+        
+        saveAndReload()
+    }
+
     // ── File generation ───────────────────────────────────────────────────────
     property var _writeProc: Process { command: []; running: false }
 

--- a/src/services/config_tab/KeybindsPage.qml
+++ b/src/services/config_tab/KeybindsPage.qml
@@ -210,6 +210,7 @@ Item {
         // Derived from service + pending
         readonly property var    _b:         KeybindService.keybinds[action]
         readonly property var    _def:       KeybindService._defaults[action]
+        readonly property bool _isUnbound: br._pillText === "Unbound"
         readonly property bool   _isPending: br.pendingCombo !== null && br.pendingCombo !== undefined
         readonly property bool   _isDefault: {
             if (!br._def) return true
@@ -354,7 +355,7 @@ Item {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter }
                 text:           br._b ? br._b.label : br.action
                 font.pixelSize: 12
-                color:          br._savedDupe ? "#f87171" : Qt.rgba(1, 1, 1, 0.68)
+                color:          br._savedDupe ? "#f87171" : (br._isUnbound ? Qt.rgba(1, 1, 1, 0.35) : Qt.rgba(1, 1, 1, 0.68))
                 Behavior on color { ColorAnimation { duration: 120 } }
             }
 
@@ -421,14 +422,23 @@ Item {
                 Rectangle {
                     height: 24; radius: 6
                     width:  _pillT.implicitWidth + 18
-                    color: (_pillH.hovered && br._interactive)
-                        ? Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.16)
-                        : Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.08)
-                    border.color: br._isPending
-                        ? Qt.rgba(1.0, 0.74, 0.22, 0.55)
-                        : Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.24)
+                    
+                    color: br._isUnbound
+                        ? Qt.rgba(1, 1, 1, 0.04)
+                        : ((_pillH.hovered && br._interactive)
+                            ? Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.16)
+                            : Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.08))
+                            
+                    border.color: br._isUnbound
+                        ? Qt.rgba(1, 1, 1, 0.1)
+                        : (br._isPending
+                            ? Qt.rgba(1.0, 0.74, 0.22, 0.55)
+                            : Qt.rgba(Theme.active.r, Theme.active.g, Theme.active.b, 0.24))
+                            
                     border.width: 1
-                    opacity: br._interactive ? 1.0 : 0.4
+                    
+                    opacity: br._interactive ? (br._isUnbound ? 0.7 : 1.0) : 0.4
+                    
                     Behavior on color        { ColorAnimation { duration: 100 } }
                     Behavior on border.color { ColorAnimation { duration: 150 } }
                     Behavior on opacity      { NumberAnimation { duration: 120 } }
@@ -438,7 +448,12 @@ Item {
                         anchors.centerIn: parent
                         text:           br._pillText
                         font.pixelSize: 10; font.family: "JetBrains Mono"
-                        color: br._isPending ? Qt.rgba(1.0, 0.74, 0.22, 1.0) : Theme.active
+                        font.italic:    br._isUnbound 
+                        
+                        color: br._isUnbound 
+                            ? Qt.rgba(1, 1, 1, 0.45) 
+                            : (br._isPending ? Qt.rgba(1.0, 0.74, 0.22, 1.0) : Theme.active)
+                            
                         Behavior on color { ColorAnimation { duration: 150 } }
                     }
                     HoverHandler { id: _pillH; cursorShape: br._interactive ? Qt.PointingHandCursor : Qt.ArrowCursor }

--- a/src/services/config_tab/KeybindsPage.qml
+++ b/src/services/config_tab/KeybindsPage.qml
@@ -32,10 +32,17 @@ Item {
         _pending = copy
     }
 
-    function _applyPending() {
+	function _applyPending() {
         var ks = Object.keys(_pending)
-        for (var i = 0; i < ks.length; i++)
-            KeybindService.updateBinding(ks[i], _pending[ks[i]].mods, _pending[ks[i]].key)
+        for (var i = 0; i < ks.length; i++) {
+            var m = _pending[ks[i]].mods
+            var k = _pending[ks[i]].key
+            if (m === "" && k === "") {
+                KeybindService.unbindBinding(ks[i])
+            } else {
+                KeybindService.updateBinding(ks[i], m, k)
+            }
+        }
         _pending = {}
         KeybindService.saveAndReload()
     }
@@ -210,14 +217,19 @@ Item {
             var k = br._isPending ? br.pendingCombo.key  : (br._b ? br._b.key  : "")
             return m === br._def.mods && k === br._def.key
         }
-        readonly property string _bindText: br._b
-            ? (br._b.mods ? br._b.mods + " + " + br._b.key : br._b.key) : "..."
+        readonly property string _bindText: {
+            if (!br._b || br._b.key === "") return "Unbound"
+            return br._b.mods ? br._b.mods + " + " + br._b.key : br._b.key
+        }
         // Show pending value in the pill when set
-        readonly property string _pillText: br._isPending
-            ? (br.pendingCombo.mods ? br.pendingCombo.mods + " + " + br.pendingCombo.key
-                                    : br.pendingCombo.key)
-            : br._bindText
-        readonly property bool   _savedDupe: KeybindService.isDuplicate(action)
+        readonly property string _pillText: {
+            if (br._isPending) {
+                if (br.pendingCombo.key === "") return "Unbound"
+                return br.pendingCombo.mods ? br.pendingCombo.mods + " + " + br.pendingCombo.key : br.pendingCombo.key
+            }
+            return br._bindText
+		}
+		readonly property bool   _savedDupe: KeybindService.isDuplicate(action)
 
         readonly property bool _interactive: root._capturing === "" || br.isCapturing
 
@@ -357,6 +369,24 @@ Item {
                     text:           "⚠ " + KeybindService.conflictsWith(br.action)
                     font.pixelSize: 9
                     color:          Qt.rgba(248/255, 113/255, 113/255, 0.75)
+                }
+
+				// Clear bind
+                Rectangle {
+                    visible: br._pillText !== "Unbound"
+                    width: 22; height: 22; radius: 6
+                    color: _clrH.hovered ? Qt.rgba(1,1,1,0.09) : "transparent"
+                    Behavior on color { ColorAnimation { duration: 100 } }
+                    Text { anchors.centerIn: parent; text: "󰩺"; font.pixelSize: 11
+                        color: _clrH.hovered ? "#ff4444" : Qt.rgba(1,1,1,0.28) }
+                    HoverHandler { id: _clrH; cursorShape: Qt.PointingHandCursor }
+                    MouseArea {
+                        anchors.fill: parent
+                        enabled: br._interactive
+                        onClicked: {
+                            root._addPending(br.action, "", "")
+                        }
+                    }
                 }
 
                 // Reset to default


### PR DESCRIPTION
## Overview

This pull request introduces automatic keybind conflict detection during installation to respect the user's existing Hyprland setup. It also enhances the Keybinds configuration UI by allowing users to explicitly unbind actions and introducing a clean, muted visual state for unassigned keys.

## Key Changes

* **Smart Installer Conflict Detection (`install-arch.sh`):**  The installer now actively queries the user's current Hyprland bindings before setup. If a conflict is found with Brain Shell's defaults, it warns the user in the terminal and automatically unbinds the conflicting Brain Shell action, preserving the user's original setup.
* **Manual Unbinding Feature:** Added a dedicated "Clear" button to the Keybinds configuration page, empowering users to easily strip keybinds from any action via the UI.
* **Refined Unbound UI State:** Implemented a new dynamic visual state for unbound keys. Actions with empty keybinds now gracefully fade into a muted, greyed-out, italicized state (`"Unbound"`) so they don't clutter or draw unnecessary attention in the settings menu.

### Testing Alternative Branches
If you'd like to test the `dev` branch (or any other branch), download the raw install script, open it in your text editor, and replace all instances of `main` with `dev` before running it.