### PR TITLE
fix(clipboard): close popup when clicking outside

### DIFF
--- a/src/popups/ClipboardPopup.qml
+++ b/src/popups/ClipboardPopup.qml
@@ -14,11 +14,10 @@ PanelWindow {
     readonly property int fw: Theme.cornerRadius
     readonly property int fh: Theme.cornerRadius
 
+    anchors.top:    true
+    anchors.left:   true
     anchors.right:  true
     anchors.bottom: true
-
-    implicitWidth:  popupWidth  + fw
-    implicitHeight: popupHeight + fh
 
     exclusionMode: ExclusionMode.Ignore
     color:         "transparent"
@@ -31,15 +30,6 @@ PanelWindow {
         id: focusGrabTimer
         interval: 15
         onTriggered: { if (root.windowVisible && Popups.clipboardOpen) root.wantsFocus = true }
-    }
-
-    mask: Region { item: maskProxy }
-    Item {
-        id: maskProxy
-        x:      root.implicitWidth  - sizer.width
-        y:      root.implicitHeight - sizer.height
-        width:  sizer.width
-        height: sizer.height
     }
 
     property bool windowVisible: false
@@ -69,6 +59,11 @@ PanelWindow {
         }
     }
     
+    MouseArea {
+        anchors.fill: parent
+        onClicked:    Popups.clipboardOpen = false
+    }
+
     Item {
         id: sizer
         anchors.right:  parent.right
@@ -82,6 +77,11 @@ PanelWindow {
 
         Behavior on width  { NumberAnimation { duration: Theme.animDuration; easing.type: Easing.InOutCubic } }
         Behavior on height { NumberAnimation { duration: Theme.animDuration; easing.type: Easing.InOutCubic } }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked:    {}
+        }
 
         PopupShape {
             anchors.fill: parent


### PR DESCRIPTION
## Overview
Hey @Brainitech, we can't use `WlrKeyboardFocus.OnDemand` because keyboard navigation only works when the cursor is over the popup. I've kept WlrKeyboardFocus.Exclusive and instead followed the `WallpaperPopup` approach by making the popup overlay cover the entire screen.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to not work as expected)

## Testing Checklist

- [ ] I have tested these changes locally and on a fresh VM install.
- [x] I have tested the QML UI on my primary resolution.
- [ ] (If applicable) I have tested UI changes on secondary monitors or different resolutions.
- [ ] (If applicable) I have verified my bash scripts run cleanly without syntax errors.

## Related Issues
[https://github.com/Brainitech/Brain_Shell/issues/74]